### PR TITLE
changed Fprintln to Fprintf

### DIFF
--- a/content/hello-world.md
+++ b/content/hello-world.md
@@ -53,7 +53,7 @@ import (
 
 func main() {
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, "Hello, you've requested: %s", r.URL.Path)
+		fmt.Fprintf(w, "Hello, you've requested: %s\n", r.URL.Path)
 	})
 
 	http.ListenAndServe(":80", nil)

--- a/public/hello-world/index.html
+++ b/public/hello-world/index.html
@@ -155,7 +155,7 @@ A handler in Go is a function with this signature:
 
 <p>Registering a request handler to the default HTTP Server is as simple as this:
 <div class="highlight" style="background: #ffffff"><pre style="line-height: 125%"><span></span>http.HandleFunc(<span style="color: #bb8844">&quot;/&quot;</span>, <span style="font-weight: bold">func</span> (w http.ResponseWriter, r <span style="font-weight: bold">*</span>http.Request) {
-	fmt.Fprintln(w, <span style="color: #bb8844">&quot;Hello, you&#39;ve requested: %s&quot;</span>, r.URL.Path)
+	fmt.Fprintf(w, <span style="color: #bb8844">&quot;Hello, you&#39;ve requested: %s\n&quot;</span>, r.URL.Path)
 })
 </pre></div>
 </p>

--- a/public/routes-using-gorilla-mux/index.html
+++ b/public/routes-using-gorilla-mux/index.html
@@ -221,7 +221,7 @@ with the variable of your router <code>r</code>.
 		title <span style="font-weight: bold">:=</span> vars[<span style="color: #bb8844">&quot;title&quot;</span>]
 		page <span style="font-weight: bold">:=</span> vars[<span style="color: #bb8844">&quot;page&quot;</span>]
 
-		fmt.Fprintln(w, <span style="color: #bb8844">&quot;You&#39;ve requested the book: %s on page %s&quot;</span>, title, page)
+		fmt.Fprintf(w, <span style="color: #bb8844">&quot;You&#39;ve requested the book: %s on page %s\n&quot;</span>, title, page)
 	})
 
 	http.ListenAndServe(<span style="color: #bb8844">&quot;:80&quot;</span>, r)


### PR DESCRIPTION
[Fprintln](https://golang.org/pkg/fmt/#Fprintln) does not take a string as a second argument and the current code just concats instead of formats

[Fprintf](https://golang.org/pkg/fmt/#Fprintf) with a `\n` is the best solution I could think of