### PR TITLE
Enforce consistent naming of articles in the menu

### DIFF
--- a/content/forms.md
+++ b/content/forms.md
@@ -1,10 +1,10 @@
 +++
 weight = 5
-title = "Forms"
+title = "Requests & Forms"
 description = "This example will show how to simulate a contact form and parse the message into a struct using the Go programming language."
 +++
 
-# Forms
+# Requests & Forms
 
 This example will show how to simulate a contact form and parse the message into a struct.
 

--- a/content/static-files.md
+++ b/content/static-files.md
@@ -1,10 +1,10 @@
 +++
 weight = 4
-title = "Assets and Files"
+title = "Assets & Files"
 description = "This example will show how to serve static files like CSS or JS from a specific directory using the http.FileServer in the Go programming language."
 +++
 
-# Assets and Files
+# Assets & Files
 
 This example will show how to serve static files like CSSs, JavaScripts or images from a specific directory.
 

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -11,7 +11,7 @@
 			<div><a href="/static-files/">Assets &amp; Files</a></div>
 			<div><a href="/basic-middleware/">Middleware (Basic)</a></div>
 			<div><a href="/advanced-middleware/">Middleware (Advanced)</a></div>
-			<div><a href="/sessions/">Session</a></div>
+			<div><a href="/sessions/">Sessions</a></div>
 			<!-- <div><a href="/hello-world/">Validation</a></div> -->
 			<div><a href="/json/">JSON</a></div>
 			<div><a href="/websockets/">Websockets</a></div>


### PR DESCRIPTION
Titles in the menu (sidebar) were not consistent with the titles of the articles.