### PR TITLE
Fix http.Dir() description

### DIFF
--- a/content/http-server.md
+++ b/content/http-server.md
@@ -33,10 +33,10 @@ For the dynamic aspect, the `http.Request` contains all information about the re
 You can read GET parameters with `r.URL.Query().Get("token")` or POST parameters (fields from an HTML form) with `r.FormValue("email")`.
 
 ## Serving static assets
-To serve static assets like JavaScript, CSS and images, we use the inbuilt `http.FileServer` and point it to a url path.
-For the file server to work properly it needs to know, where to serve files from. We can do this like so:
+To serve static assets like JavaScript, CSS and images, we use the inbuilt `http.FileServer` and point it to the appropriate folder within your webserver's filesystem.
+We can do this like so:
 {{< highlight go >}}
-fs := http.FileServer(http.Dir("static/"))
+fs := http.FileServer(http.Dir("/var/www/html/static/"))
 {{< / highlight >}}
 
 Once our file server is in place, we just need to point a url path at it, just like we did with the dynamic requests.
@@ -67,7 +67,7 @@ func main() {
 		fmt.Fprintf(w, "Welcome to my website!")
 	})
 
-	fs := http.FileServer(http.Dir("static/"))
+	fs := http.FileServer(http.Dir("/var/www/html/static/"))
 	http.Handle("/static/", http.StripPrefix("/static/", fs))
 
 	http.ListenAndServe(":80", nil)

--- a/public/http-server/index.html
+++ b/public/http-server/index.html
@@ -197,9 +197,9 @@ You can read GET parameters with <code>r.URL.Query().Get(&quot;token&quot;)</cod
 
 <h2 id="serving-static-assets">Serving static assets</h2>
 
-<p>To serve static assets like JavaScript, CSS and images, we use the inbuilt <code>http.FileServer</code> and point it to a url path.
-For the file server to work properly it needs to know, where to serve files from. We can do this like so:
-<div class="highlight"><pre style="background-color:#fff;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-go" data-lang="go">fs <span style="font-weight:bold">:=</span> http.FileServer(http.Dir(<span style="color:#b84">&#34;static/&#34;</span>))</code></pre></div></p>
+<p>To serve static assets like JavaScript, CSS and images, we use the inbuilt <code>http.FileServer</code> and point it to the appropriate folder within your webserver's filesystem.
+We can do this like so:
+<div class="highlight"><pre style="background-color:#fff;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-go" data-lang="go">fs <span style="font-weight:bold">:=</span> http.FileServer(http.Dir(<span style="color:#b84">&#34;/var/www/html/static/&#34;</span>))</code></pre></div></p>
 
 <p>Once our file server is in place, we just need to point a url path at it, just like we did with the dynamic requests.
 One thing to note: In order to serve files correctly, we need to strip away a part of the url path. Usually this is the name of the directory our files live in.
@@ -226,7 +226,7 @@ As you can guess, Go has also an inbuilt HTTP server, we can start faily quickly
 		fmt.Fprintf(w, <span style="color:#b84">&#34;Welcome to my website!&#34;</span>)
 	})
 
-	fs <span style="font-weight:bold">:=</span> http.FileServer(http.Dir(<span style="color:#b84">&#34;static/&#34;</span>))
+	fs <span style="font-weight:bold">:=</span> http.FileServer(http.Dir(<span style="color:#b84">&#34;/var/www/html/static/&#34;</span>))
 	http.Handle(<span style="color:#b84">&#34;/static/&#34;</span>, http.StripPrefix(<span style="color:#b84">&#34;/static/&#34;</span>, fs))
 
 	http.ListenAndServe(<span style="color:#b84">&#34;:80&#34;</span>, <span style="font-weight:bold">nil</span>)


### PR DESCRIPTION
This commit fixes an issue with the http.Dir() description.
`http.Dir()` takes a folder within the filesystem as an argument, not an url path.